### PR TITLE
Add onboarding and agent UI

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,6 +1,9 @@
-import type { ChatMessage } from "./types";
+import type { Agent, ChatMessage } from "./types";
 
-import TerminalChat from "./components/chat/terminal-chat";
+import SwarmChat from "./components/chat/swarm-chat";
+import GitHubLogin from "./components/onboarding/github-login";
+import RepoPicker from "./components/onboarding/repo-picker";
+import AgentLogViewer from "./components/agents/agent-log-viewer";
 import { APP_NAME, CLI_VERSION } from "./constants/app";
 import { checkInGit } from "./utils/check-in-git";
 import { ConfirmInput } from "@inkjs/ui";
@@ -26,7 +29,13 @@ export default function App(): JSX.Element {
   const { internal_eventEmitter } = useStdin();
   internal_eventEmitter.setMaxListeners(20);
 
-  // Simple message handler - echo back for demo
+  const [view, setView] = useState<'login' | 'repo' | 'chat' | 'logs'>(
+    'login',
+  );
+  const [agents, setAgents] = useState<Array<Agent>>([]);
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
+
+  // Simple message handler - echo back and spawn mock agent
   const handleSendMessage = (content: string) => {
     const userMessage: ChatMessage = {
       id: Date.now().toString(),
@@ -43,34 +52,84 @@ export default function App(): JSX.Element {
     };
 
     setMessages((prev) => [...prev, userMessage, assistantMessage]);
+
+    const agentId = `${Date.now()}`;
+    const agentName = `Agent-${agents.length + 1}`;
+    const newAgent: Agent = { id: agentId, name: agentName, status: "running", logs: [] };
+    setAgents((prev) => [...prev, newAgent]);
+
+    // Mock log streaming
+    const steps = [
+      "Starting task analysis...",
+      "Creating branch feat/demo",
+      "Analyzing existing code...",
+      "Writing changes...",
+      "Running tests...",
+      "Done",
+    ];
+    let idx = 0;
+    const interval = setInterval(() => {
+      idx += 1;
+      setAgents((prev) =>
+        prev.map((a) =>
+          a.id === agentId
+            ? {
+                ...a,
+                logs: [...a.logs, `[${new Date().toLocaleTimeString()}] ${steps[idx - 1]}`],
+                status: idx === steps.length ? "completed" : "running",
+              }
+            : a,
+        ),
+      );
+      if (idx === steps.length) clearInterval(interval);
+    }, 2000);
   };
 
   // Git repository check (keep this pattern from original)
   if (!accepted && inGitRepo) {
     return (
       <Box flexDirection="column" gap={1}>
-        <Text bold color="yellow">
-          ⚠️ Git Repository Detected
-        </Text>
+        <Text bold color="yellow">⚠️ Git Repository Detected</Text>
         <Text>
           This appears to be a git repository. The chat app will create example
           files for demonstration.
         </Text>
         <Text dimColor>Continue anyway?</Text>
-        <ConfirmInput
-          onConfirm={() => setAccepted(true)}
-          onCancel={() => app.exit()}
-        />
+        <ConfirmInput onConfirm={() => setAccepted(true)} onCancel={() => app.exit()} />
       </Box>
     );
   }
 
+  if (view === 'login') {
+    return <GitHubLogin onLogin={() => setView('repo')} />;
+  }
+
+  if (view === 'repo') {
+    const repos = [
+      { label: 'sample-repo-1', value: 'repo1' },
+      { label: 'sample-repo-2', value: 'repo2' },
+      { label: 'sample-repo-3', value: 'repo3' },
+    ];
+    return <RepoPicker repos={repos} onSelect={() => setView('chat')} />;
+  }
+
+  if (view === 'logs' && selectedAgent) {
+    const agent = agents.find((a) => a.id === selectedAgent)!;
+    return <AgentLogViewer agent={agent} onExit={() => setView('chat')} />;
+  }
+
   return (
-    <TerminalChat
+    <SwarmChat
       messages={messages}
+      agents={agents}
       onSendMessage={handleSendMessage}
+      onSelectAgent={(id) => {
+        setSelectedAgent(id);
+        setView('logs');
+      }}
       version={CLI_VERSION}
       cwd={cwd}
     />
   );
 }
+

--- a/src/components/agents/agent-log-viewer.tsx
+++ b/src/components/agents/agent-log-viewer.tsx
@@ -1,0 +1,27 @@
+import type { Agent } from "../../types";
+import { Box, Text, useInput } from "ink";
+import React from "react";
+
+export default function AgentLogViewer({
+  agent,
+  onExit,
+}: {
+  agent: Agent;
+  onExit: () => void;
+}): JSX.Element {
+  useInput((input, key) => {
+    if (key.escape) onExit();
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" padding={1} height={process.stdout.rows || 24}>
+      <Text bold>{agent.name} Live Logs</Text>
+      <Box flexDirection="column" flexGrow={1} marginTop={1}>
+        {agent.logs.map((line, idx) => (
+          <Text key={idx}>{line}</Text>
+        ))}
+      </Box>
+      <Text dimColor>[ESC] Back to chat</Text>
+    </Box>
+  );
+}

--- a/src/components/agents/agent-side-panel.tsx
+++ b/src/components/agents/agent-side-panel.tsx
@@ -1,0 +1,50 @@
+import type { Agent } from "../../types";
+import Spinner from "../vendor/ink-spinner";
+import { Box, Text, useInput } from "ink";
+import React, { useState } from "react";
+
+export default function AgentSidePanel({
+  agents,
+  onSelect,
+}: {
+  agents: Agent[];
+  onSelect: (id: string) => void;
+}): JSX.Element {
+  const [cursor, setCursor] = useState(0);
+
+  useInput((input, key) => {
+    if (key.upArrow) {
+      setCursor((c) => Math.max(0, c - 1));
+    } else if (key.downArrow) {
+      setCursor((c) => Math.min(agents.length - 1, c + 1));
+    } else if (key.return) {
+      if (agents[cursor]) onSelect(agents[cursor]!.id);
+    }
+  });
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text bold>Active Agents</Text>
+      {agents.map((agent, i) => {
+        const selected = i === cursor;
+        const statusIcon =
+          agent.status === "completed"
+            ? "✅"
+            : agent.status === "running"
+            ? <Spinner />
+            : "⌛";
+        return (
+          <Box key={agent.id}>
+            <Text color={selected ? "cyan" : undefined}>{selected ? "› " : "  "}</Text>
+            <Text color={selected ? "cyan" : undefined}>{agent.name}: </Text>
+            {typeof statusIcon === "string" ? (
+              <Text>{statusIcon}</Text>
+            ) : (
+              statusIcon
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/components/chat/swarm-chat.tsx
+++ b/src/components/chat/swarm-chat.tsx
@@ -1,0 +1,49 @@
+import type { Agent, ChatMessage } from "../../types";
+import TerminalChatInput from "./terminal-chat-input";
+import TerminalHeader from "./terminal-header";
+import TerminalMessageHistory from "./terminal-message-history";
+import AgentSidePanel from "../agents/agent-side-panel";
+import { useTerminalSize } from "../../hooks/use-terminal-size";
+import { Box } from "ink";
+import React from "react";
+
+export default function SwarmChat({
+  messages,
+  agents,
+  onSendMessage,
+  onSelectAgent,
+  cwd,
+  version,
+}: {
+  messages: ChatMessage[];
+  agents: Agent[];
+  onSendMessage: (text: string) => void;
+  onSelectAgent: (id: string) => void;
+  cwd: string;
+  version: string;
+}): JSX.Element {
+  const { rows, columns } = useTerminalSize();
+  const sideWidth = Math.min(30, Math.max(20, Math.floor(columns * 0.3)));
+
+  return (
+    <Box flexDirection="column" height={rows}>
+      <TerminalHeader
+        terminalRows={rows}
+        version={version}
+        PWD={cwd}
+        model="Mock"
+        approvalPolicy="demo"
+        colorsByPolicy={{ demo: "cyan" }}
+      />
+      <Box flexGrow={1} flexDirection="row">
+        <Box flexDirection="column" flexGrow={1}>
+          <TerminalMessageHistory messages={messages} terminalColumns={columns - sideWidth} />
+          <TerminalChatInput onSendMessage={onSendMessage} terminalColumns={columns - sideWidth} />
+        </Box>
+        <Box width={sideWidth} borderLeftStyle="single" borderColor="gray">
+          <AgentSidePanel agents={agents} onSelect={onSelectAgent} />
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/onboarding/github-login.tsx
+++ b/src/components/onboarding/github-login.tsx
@@ -1,0 +1,21 @@
+import { Box, Text, useInput } from "ink";
+import React from "react";
+
+export default function GitHubLogin({
+  onLogin,
+}: {
+  onLogin: () => void;
+}): JSX.Element {
+  useInput((input, key) => {
+    if (key.return) {
+      onLogin();
+    }
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" padding={1}>
+      <Text bold>Sign in with GitHub</Text>
+      <Text dimColor>Press Enter to mock login</Text>
+    </Box>
+  );
+}

--- a/src/components/onboarding/repo-picker.tsx
+++ b/src/components/onboarding/repo-picker.tsx
@@ -1,0 +1,23 @@
+import SelectInput from "../select-input/select-input";
+import { Box, Text } from "ink";
+import React from "react";
+
+export interface RepoItem {
+  label: string;
+  value: string;
+}
+
+export default function RepoPicker({
+  repos,
+  onSelect,
+}: {
+  repos: RepoItem[];
+  onSelect: (repo: RepoItem) => void;
+}): JSX.Element {
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" padding={1}>
+      <Text bold>Select a repository</Text>
+      <SelectInput items={repos} onSelect={onSelect} />
+    </Box>
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,4 +13,13 @@ export interface ChatSession {
   title?: string;
 }
 
+export interface Agent {
+  id: string;
+  name: string;
+  status: AgentStatus;
+  logs: string[];
+}
+
+export type AgentStatus = 'queued' | 'running' | 'completed';
+
 export type OverlayMode = 'none' | 'help' | 'history';


### PR DESCRIPTION
## Summary
- add new agent and onboarding UI components
- extend app with login, repo picker, agent logs, and side panel
- update types with agent definitions

## Testing
- `bun test` *(fails: Cannot find packages)*
- `bun lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6844b69b49008332a3dec02e1d1406ad