### PR TITLE
Add mock task manager TUI

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -12,8 +12,8 @@ if (major < 22) {
   );
 }
 
-import App from "./app";
 import OnboardingApp from "./components/onboarding/onboarding-app";
+import TaskManagerApp from "./components/task-manager/task-manager-app";
 import { setInkRenderer, onExit } from "./utils/terminal";
 import { isAlreadyOnboarded, shouldSkipOnboarding } from "./utils/onboarding";
 import { render } from "ink";
@@ -67,7 +67,7 @@ function MainApp() {
     return <OnboardingApp onComplete={() => setOnboardingComplete(true)} />;
   }
   
-  return <App />;
+  return <TaskManagerApp />;
 }
 
 // Start the app and capture the Ink renderer instance

--- a/src/components/task-manager/hooks/use-task-manager-flow.ts
+++ b/src/components/task-manager/hooks/use-task-manager-flow.ts
@@ -1,0 +1,44 @@
+import { useState, useCallback } from 'react';
+import type { Repository, Issue } from '../mocks/mock-data';
+
+export type ManagerScreen =
+  | 'repo-select'
+  | 'download'
+  | 'dashboard'
+  | 'task-detail'
+  | 'task-config'
+  | 'settings'
+  | 'logs';
+
+export function useTaskManagerFlow() {
+  const [screen, setScreen] = useState<ManagerScreen>('repo-select');
+  const [selectedRepo, setSelectedRepo] = useState<Repository | null>(null);
+  const [currentIssue, setCurrentIssue] = useState<Issue | null>(null);
+
+  const toRepoSelect = useCallback(() => setScreen('repo-select'), []);
+  const toDownload = useCallback((repo: Repository) => {
+    setSelectedRepo(repo);
+    setScreen('download');
+  }, []);
+  const toDashboard = useCallback(() => setScreen('dashboard'), []);
+  const toSettings = useCallback(() => setScreen('settings'), []);
+  const toTaskDetail = useCallback((issue: Issue) => {
+    setCurrentIssue(issue);
+    setScreen('task-detail');
+  }, []);
+  const toTaskConfig = useCallback(() => setScreen('task-config'), []);
+  const toLogs = useCallback(() => setScreen('logs'), []);
+
+  return {
+    screen,
+    selectedRepo,
+    currentIssue,
+    toRepoSelect,
+    toDownload,
+    toDashboard,
+    toSettings,
+    toTaskDetail,
+    toTaskConfig,
+    toLogs,
+  };
+}

--- a/src/components/task-manager/mocks/mock-data.ts
+++ b/src/components/task-manager/mocks/mock-data.ts
@@ -1,0 +1,42 @@
+export interface Repository {
+  name: string;
+  active: number;
+  done: number;
+  lastUsed: string;
+  openIssues?: number;
+}
+
+export interface Issue {
+  id: number;
+  title: string;
+  status: string;
+}
+
+export interface LogLine {
+  time: string;
+  message: string;
+}
+
+export const recentRepositories: Repository[] = [
+  { name: 'acme/webapp', active: 3, done: 12, lastUsed: '2h ago' },
+  { name: 'acme/mobile-app', active: 1, done: 8, lastUsed: 'yesterday' },
+  { name: 'personal/blog-engine', active: 0, done: 5, lastUsed: '3d ago' },
+];
+
+export const githubRepositories: Repository[] = [
+  { name: 'acme/api-gateway', active: 0, done: 0, lastUsed: '', openIssues: 42 },
+  { name: 'acme/documentation', active: 0, done: 0, lastUsed: '', openIssues: 8 },
+  { name: 'tools/deployment-scripts', active: 0, done: 0, lastUsed: '', openIssues: 3 },
+];
+
+export const issues: Issue[] = [
+  { id: 45, title: '[FEATURE] Implement webhook handlers', status: 'open' },
+  { id: 44, title: '[BUG] Fix memory leak in worker threads', status: 'open' },
+  { id: 43, title: '[TASK] Update dependencies', status: 'open' },
+];
+
+export const logs: LogLine[] = [
+  { time: '15:18:45', message: 'INFO  Starting task execution' },
+  { time: '15:18:47', message: 'AGENT Reading issue description...' },
+  { time: '15:19:56', message: 'PR    Pull request created: #89' },
+];

--- a/src/components/task-manager/screens/dashboard-screen.tsx
+++ b/src/components/task-manager/screens/dashboard-screen.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { Issue } from '../mocks/mock-data';
+
+export interface DashboardProps {
+  issues: Issue[];
+  onSelectIssue: (issue: Issue) => void;
+  onSettings: () => void;
+}
+
+export default function DashboardScreen({ issues, onSelectIssue, onSettings }: DashboardProps): JSX.Element {
+  const [index, setIndex] = useState(0);
+
+  useInput((input, key) => {
+    if (key.downArrow) setIndex((i) => Math.min(i + 1, issues.length - 1));
+    if (key.upArrow) setIndex((i) => Math.max(i - 1, 0));
+    if (key.return) onSelectIssue(issues[index]);
+    if (input === 's') onSettings();
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor="blue" height="100%">
+      <Box justifyContent="space-between" paddingX={2} paddingY={1}>
+        <Text bold color="blue">Task Dashboard</Text>
+        <Text>[s] Settings</Text>
+      </Box>
+      <Box flexDirection="column" paddingX={2} flexGrow={1}>
+        {issues.map((iss, i) => (
+          <Text key={iss.id} color={i === index ? 'cyan' : undefined}>
+            {i === index ? '› ' : '  '}
+            #{iss.id} {iss.title}
+          </Text>
+        ))}
+      </Box>
+      <Box borderStyle="single" borderTop={true} borderBottom={false} borderLeft={false} borderRight={false} paddingX={2} paddingY={1}>
+        <Text dimColor>[Enter] View Issue  [s] Settings</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/task-manager/screens/download-screen.tsx
+++ b/src/components/task-manager/screens/download-screen.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Text } from 'ink';
+import type { Repository } from '../mocks/mock-data';
+
+export interface DownloadScreenProps {
+  repo: Repository;
+  onComplete: () => void;
+}
+
+export default function DownloadScreen({ repo, onComplete }: DownloadScreenProps): JSX.Element {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setProgress((p) => {
+        const next = Math.min(p + 10, 100);
+        if (next === 100) {
+          clearInterval(id);
+          setTimeout(onComplete, 500);
+        }
+        return next;
+      });
+    }, 100);
+    return () => clearInterval(id);
+  }, [onComplete]);
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor="blue" height="100%">
+      <Box justifyContent="center" paddingY={1}>
+        <Text bold color="blue">Setting up: {repo.name}</Text>
+      </Box>
+      <Box flexGrow={1} justifyContent="center" alignItems="center">
+        <Text>{`Cloning repository... ${progress}%`}</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/task-manager/screens/full-log-screen.tsx
+++ b/src/components/task-manager/screens/full-log-screen.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { LogLine } from '../mocks/mock-data';
+
+export interface LogScreenProps {
+  logs: LogLine[];
+  onBack: () => void;
+}
+
+export default function FullLogScreen({ logs, onBack }: LogScreenProps): JSX.Element {
+  useInput((input, key) => {
+    if (key.escape) onBack();
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor="blue" height="100%">
+      <Box justifyContent="center" paddingY={1}>
+        <Text bold color="blue">Full Log</Text>
+      </Box>
+      <Box flexDirection="column" paddingX={2} flexGrow={1}>
+        {logs.map((l, i) => (
+          <Text key={i}>{`[${l.time}] ${l.message}`}</Text>
+        ))}
+      </Box>
+      <Box borderStyle="single" borderTop={true} borderBottom={false} borderLeft={false} borderRight={false} paddingX={2} paddingY={1}>
+        <Text dimColor>[Esc] Back</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/task-manager/screens/repo-select-screen.tsx
+++ b/src/components/task-manager/screens/repo-select-screen.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { Repository } from '../mocks/mock-data';
+
+export interface RepoSelectProps {
+  recent: Repository[];
+  github: Repository[];
+  onSelect: (repo: Repository) => void;
+  onExit?: () => void;
+}
+
+export default function RepoSelectScreen({
+  recent,
+  github,
+  onSelect,
+  onExit,
+}: RepoSelectProps): JSX.Element {
+  const [index, setIndex] = useState(0);
+  const all = [...recent, ...github];
+
+  useInput((input, key) => {
+    if (key.downArrow) setIndex((i) => Math.min(i + 1, all.length - 1));
+    if (key.upArrow) setIndex((i) => Math.max(i - 1, 0));
+    if (key.return) onSelect(all[index]);
+    if (key.escape) onExit?.();
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor="blue" height="100%">
+      <Box justifyContent="center" paddingY={1}>
+        <Text bold color="blue">Select Repository</Text>
+      </Box>
+      <Box flexDirection="column" paddingX={2} flexGrow={1}>
+        {all.map((r, i) => (
+          <Text key={r.name} color={i === index ? 'cyan' : undefined}>
+            {i === index ? '› ' : '  '}
+            {r.name}
+          </Text>
+        ))}
+      </Box>
+      <Box borderStyle="single" borderTop={true} borderBottom={false} borderLeft={false} borderRight={false} paddingX={2} paddingY={1}>
+        <Text dimColor>[Enter] Select  [Esc] Back</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/task-manager/screens/settings-screen.tsx
+++ b/src/components/task-manager/screens/settings-screen.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Box, Text, useInput } from 'ink';
+
+export interface SettingsProps {
+  onBack: () => void;
+}
+
+export default function SettingsScreen({ onBack }: SettingsProps): JSX.Element {
+  useInput((input, key) => {
+    if (key.escape) onBack();
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor="blue" height="100%">
+      <Box justifyContent="center" paddingY={1}>
+        <Text bold color="blue">Settings</Text>
+      </Box>
+      <Box flexGrow={1} paddingX={2}>
+        <Text>Default Model: claude-3-5-sonnet</Text>
+        <Text>Preferred Editor: Cursor</Text>
+      </Box>
+      <Box borderStyle="single" borderTop={true} borderBottom={false} borderLeft={false} borderRight={false} paddingX={2} paddingY={1}>
+        <Text dimColor>[Esc] Back</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/task-manager/screens/task-config-screen.tsx
+++ b/src/components/task-manager/screens/task-config-screen.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Box, Text, useInput } from 'ink';
+
+export interface TaskConfigProps {
+  onBack: () => void;
+}
+
+export default function TaskConfigScreen({ onBack }: TaskConfigProps): JSX.Element {
+  useInput((input, key) => {
+    if (key.escape) onBack();
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor="blue" height="100%">
+      <Box justifyContent="center" paddingY={1}>
+        <Text bold color="blue">Configure Task</Text>
+      </Box>
+      <Box flexGrow={1} paddingX={2}>
+        <Text>Model: [claude-3-5-sonnet ▼]</Text>
+        <Text>Custom Instructions...</Text>
+      </Box>
+      <Box borderStyle="single" borderTop={true} borderBottom={false} borderLeft={false} borderRight={false} paddingX={2} paddingY={1}>
+        <Text dimColor>[Esc] Back</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/task-manager/screens/task-detail-screen.tsx
+++ b/src/components/task-manager/screens/task-detail-screen.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { Issue } from '../mocks/mock-data';
+
+export interface TaskDetailProps {
+  issue: Issue;
+  onBack: () => void;
+  onLogs: () => void;
+}
+
+export default function TaskDetailScreen({ issue, onBack, onLogs }: TaskDetailProps): JSX.Element {
+  useInput((input, key) => {
+    if (key.escape) onBack();
+    if (input === 'l') onLogs();
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor="blue" height="100%">
+      <Box justifyContent="center" paddingY={1}>
+        <Text bold color="blue">Task Detail - #{issue.id}</Text>
+      </Box>
+      <Box flexGrow={1} paddingX={2}>
+        <Text>{issue.title}</Text>
+      </Box>
+      <Box borderStyle="single" borderTop={true} borderBottom={false} borderLeft={false} borderRight={false} paddingX={2} paddingY={1}>
+        <Text dimColor>[l] View Logs  [Esc] Back</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/task-manager/task-manager-app.tsx
+++ b/src/components/task-manager/task-manager-app.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { Box } from "ink";
+import { useTaskManagerFlow } from "./hooks/use-task-manager-flow";
+import {
+  recentRepositories,
+  githubRepositories,
+  issues,
+  logs,
+} from "./mocks/mock-data";
+import RepoSelectScreen from "./screens/repo-select-screen";
+import DownloadScreen from "./screens/download-screen";
+import DashboardScreen from "./screens/dashboard-screen";
+import TaskDetailScreen from "./screens/task-detail-screen";
+import TaskConfigScreen from "./screens/task-config-screen";
+import SettingsScreen from "./screens/settings-screen";
+import FullLogScreen from "./screens/full-log-screen";
+
+export interface TaskManagerAppProps {
+  onExit?: () => void;
+}
+
+export default function TaskManagerApp({
+  onExit,
+}: TaskManagerAppProps): JSX.Element {
+  const flow = useTaskManagerFlow();
+
+  const renderScreen = () => {
+    switch (flow.screen) {
+      case "repo-select":
+        return (
+          <RepoSelectScreen
+            recent={recentRepositories}
+            github={githubRepositories}
+            onSelect={flow.toDownload}
+            onExit={onExit}
+          />
+        );
+      case "download":
+        return flow.selectedRepo ? (
+          <DownloadScreen
+            repo={flow.selectedRepo}
+            onComplete={flow.toDashboard}
+          />
+        ) : null;
+      case "dashboard":
+        return (
+          <DashboardScreen
+            issues={issues}
+            onSelectIssue={flow.toTaskDetail}
+            onSettings={flow.toSettings}
+          />
+        );
+      case "task-detail":
+        return flow.currentIssue ? (
+          <TaskDetailScreen
+            issue={flow.currentIssue}
+            onBack={flow.toDashboard}
+            onLogs={flow.toLogs}
+          />
+        ) : null;
+      case "task-config":
+        return <TaskConfigScreen onBack={flow.toDashboard} />;
+      case "settings":
+        return <SettingsScreen onBack={flow.toDashboard} />;
+      case "logs":
+        return flow.currentIssue ? (
+          <FullLogScreen
+            logs={logs}
+            onBack={() => flow.toTaskDetail(flow.currentIssue!)}
+          />
+        ) : null;
+      default:
+        return null;
+    }
+  };
+
+  return <Box height="100%">{renderScreen()}</Box>;
+}

--- a/tests/task-manager/basic-rendering.test.tsx
+++ b/tests/task-manager/basic-rendering.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import stripAnsi from 'strip-ansi';
+
+import RepoSelectScreen from '../../src/components/task-manager/screens/repo-select-screen.js';
+import DownloadScreen from '../../src/components/task-manager/screens/download-screen.js';
+import DashboardScreen from '../../src/components/task-manager/screens/dashboard-screen.js';
+import TaskDetailScreen from '../../src/components/task-manager/screens/task-detail-screen.js';
+import SettingsScreen from '../../src/components/task-manager/screens/settings-screen.js';
+import TaskConfigScreen from '../../src/components/task-manager/screens/task-config-screen.js';
+import FullLogScreen from '../../src/components/task-manager/screens/full-log-screen.js';
+import { recentRepositories, githubRepositories, issues, logs } from '../../src/components/task-manager/mocks/mock-data.js';
+
+describe('Task Manager Screens render', () => {
+  it('RepoSelectScreen shows repositories', () => {
+    const { lastFrame } = render(
+      <RepoSelectScreen recent={recentRepositories} github={githubRepositories} onSelect={() => {}} />
+    );
+    const frame = stripAnsi(lastFrame() || '');
+    expect(frame).toContain('Select Repository');
+    expect(frame).toContain(recentRepositories[0].name);
+  });
+
+  it('DownloadScreen shows progress text', () => {
+    const { lastFrame } = render(
+      <DownloadScreen repo={recentRepositories[0]} onComplete={() => {}} />
+    );
+    const frame = stripAnsi(lastFrame() || '');
+    expect(frame).toContain('Setting up');
+  });
+
+  it('DashboardScreen lists issues', () => {
+    const { lastFrame } = render(
+      <DashboardScreen issues={issues} onSelectIssue={() => {}} onSettings={() => {}} />
+    );
+    const frame = stripAnsi(lastFrame() || '');
+    expect(frame).toContain('Task Dashboard');
+    expect(frame).toContain(issues[0].title);
+  });
+
+  it('TaskDetailScreen displays issue info', () => {
+    const { lastFrame } = render(
+      <TaskDetailScreen issue={issues[0]} onBack={() => {}} onLogs={() => {}} />
+    );
+    const frame = stripAnsi(lastFrame() || '');
+    expect(frame).toContain('Task Detail');
+    expect(frame).toContain(issues[0].title);
+  });
+
+  it('SettingsScreen renders', () => {
+    const { lastFrame } = render(<SettingsScreen onBack={() => {}} />);
+    const frame = stripAnsi(lastFrame() || '');
+    expect(frame).toContain('Settings');
+  });
+
+  it('TaskConfigScreen renders', () => {
+    const { lastFrame } = render(<TaskConfigScreen onBack={() => {}} />);
+    const frame = stripAnsi(lastFrame() || '');
+    expect(frame).toContain('Configure Task');
+  });
+
+  it('FullLogScreen shows log lines', () => {
+    const { lastFrame } = render(<FullLogScreen logs={logs} onBack={() => {}} />);
+    const frame = stripAnsi(lastFrame() || '');
+    expect(frame).toContain('Full Log');
+    expect(frame).toContain(logs[0].message);
+  });
+});


### PR DESCRIPTION
## Summary
- implement mock task manager screens based on design doc
- hook up new flow in cli
- test render output for each screen
- fix log screen return

## Testing
- `bun run test` *(fails: 10 failed, 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684568f48158833292761034248f0484