### PR TITLE
fix(setup): make setup script work for forked repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ gh auth status
 
 ## Getting Started
 
-[![Use this template](https://img.shields.io/badge/Use%20this%20template-2ea44f?style=for-the-badge)](https://github.com/org/claude-swarm/generate)
+[![Use this template](https://img.shields.io/badge/Use%20this%20template-2ea44f?style=for-the-badge)](https://github.com/pythonpete32/claude-swarm/generate)
 
 1. Click **"Use this template"** button above
 2. Name your new repository

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -80,8 +80,8 @@ When you run `worktree-task.sh feature-auth`, it creates:
 
 ```
 /parent-directory/
-├── claude-swarm/           # Main repository
-└── claude-swarm-feature-auth/  # Worktree (sibling directory)
+├── your-repo-name/           # Main repository
+└── your-repo-name-feature-auth/  # Worktree (sibling directory)
 ```
 
 This keeps worktrees separate from the main repository while maintaining easy access.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -43,7 +43,23 @@ echo "✅ All dependencies check out"
 REPO_OWNER=$(gh repo view --json owner --jq '.owner.login')
 REPO_NAME=$(gh repo view --json name --jq '.name')
 
+# Validate repository name for project creation
+if [[ ! "$REPO_NAME" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+    echo "❌ Error: Repository name '$REPO_NAME' contains invalid characters for project creation"
+    echo "   GitHub project names must contain only alphanumeric characters, dots, hyphens, and underscores"
+    exit 1
+fi
+
 echo "📁 Repository: ${REPO_OWNER}/${REPO_NAME}"
+
+# Check if this appears to be a forked repository
+REPO_INFO=$(gh repo view --json isFork,parent)
+IS_FORK=$(echo "$REPO_INFO" | jq -r '.isFork')
+if [ "$IS_FORK" = "true" ]; then
+    PARENT_REPO=$(echo "$REPO_INFO" | jq -r '.parent.nameWithOwner')
+    echo "🍴 This appears to be a fork of: $PARENT_REPO"
+    echo "✅ Setup will use your repository name ($REPO_NAME) for project creation"
+fi
 
 # Check if project already exists
 echo "🔍 Checking for existing project..."


### PR DESCRIPTION
## Summary
- Fixed template button URL in README.md from placeholder to actual repository
- Updated documentation examples to use generic repository names instead of hardcoded "claude-swarm"
- Enhanced setup script with fork detection and validation for better user experience

## Test plan
- [x] Verified setup script syntax and functionality
- [x] Tested repository name detection works with forked repositories
- [x] Confirmed template URL points to correct repository
- [x] Validated fork detection provides clear user feedback
- [x] Ensured all scripts work regardless of repository name

🤖 Generated with [Claude Code](https://claude.ai/code)